### PR TITLE
Bugfix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "illuminate/support": "~5.1",
         "illuminate/session": "~5.1",
         "league/flysystem": "~1.0",
-        "tomwalder/php-gds": "3.0.2",
+        "tomwalder/php-gds": "3.0.1",
         "google/cloud": "^0.39",
         "madewithlove/illuminate-psr-cache-bridge": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "illuminate/support": "~5.1",
         "illuminate/session": "~5.1",
         "league/flysystem": "~1.0",
-        "tomwalder/php-gds": "~3.0",
+        "tomwalder/php-gds": "3.0.2",
         "google/cloud": "^0.39",
         "madewithlove/illuminate-psr-cache-bridge": "^1.0"
     },


### PR DESCRIPTION
The tomwalder/php-gds package has an error in its composer.json preventing installation of your package, making a static dependency to the latest 3.0 tag (3.0.1) allows installation to continue. 